### PR TITLE
Fix UnsupportedClassVersionError in production

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,3 +12,12 @@ repositories {
 dependencies {
     implementation files('libs/bta.jar')
 }
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_1_8
+	targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType(JavaCompile) {
+	options.release.set 8
+}


### PR DESCRIPTION
This should fix these errors.

```
[12:39:22] [Minecraft main thread] Error loading class "io.github.pkstdev.bwf.BetterWithFurnaces": java.lang.UnsupportedClassVersionError: io/github/pkstdev/bwf/BetterWithFurnaces has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
[12:39:22] [Minecraft main thread] Error loading class "io.github.pkstdev.bwf.block.BlockExtendedFurnace": java.lang.UnsupportedClassVersionError: io/github/pkstdev/bwf/block/BlockExtendedFurnace has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
[12:39:22] [Minecraft main thread] Error loading class "io.github.pkstdev.bwf.block.TileEntityExtendedFurnace": java.lang.UnsupportedClassVersionError: io/github/pkstdev/bwf/block/TileEntityExtendedFurnace has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
[12:39:22] [Minecraft main thread] Error loading class "io.github.pkstdev.bwf.util.RecipeHelper": java.lang.UnsupportedClassVersionError: io/github/pkstdev/bwf/util/RecipeHelper has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
[12:39:22] [Minecraft main thread] Error loading class "io.github.pkstdev.bwf.util.TileEntityHelper": java.lang.UnsupportedClassVersionError: io/github/pkstdev/bwf/util/TileEntityHelper has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```